### PR TITLE
Fix: Check existence of template content before formatting SMS content

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -58,7 +58,10 @@ func (a *AmazonSNSClient) SendMessage(param map[string]string, targetPhoneNumber
 		return fmt.Errorf("missing parameter: code")
 	}
 
-	bodyContent := fmt.Sprintf(a.template, code)
+	bodyContent := code
+	if a.template != "" {
+		bodyContent = fmt.Sprintf(a.template, code)
+	}
 
 	if len(targetPhoneNumber) == 0 {
 		return fmt.Errorf("missing parameter: targetPhoneNumber")

--- a/huyi.go
+++ b/huyi.go
@@ -57,7 +57,10 @@ func (hc *HuyiClient) SendMessage(param map[string]string, targetPhoneNumber ...
 	}
 
 	_now := strconv.FormatInt(time.Now().Unix(), 10)
-	smsContent := fmt.Sprintf(hc.template, code)
+	smsContent := code
+	if hc.template != "" {
+		smsContent = fmt.Sprintf(hc.template, code)
+	}
 	v := url.Values{}
 	v.Set("account", hc.appId)
 	v.Set("content", smsContent)

--- a/infobip.go
+++ b/infobip.go
@@ -88,7 +88,10 @@ func (c *InfobipClient) SendMessage(param map[string]string, targetPhoneNumber .
 	}
 
 	endpoint := fmt.Sprintf("%s/sms/2/text/advanced", c.baseUrl)
-	text := fmt.Sprintf(c.template, code)
+	text := code
+	if c.template != "" {
+		text = fmt.Sprintf(c.template, code)
+	}
 
 	messageData := MessageData{
 		Messages: []Message{

--- a/smsbao.go
+++ b/smsbao.go
@@ -56,7 +56,12 @@ func (c *SmsBaoClient) SendMessage(param map[string]string, targetPhoneNumber ..
 		return fmt.Errorf("missing parameter: targetPhoneNumber")
 	}
 
-	smsContent := url.QueryEscape("【" + c.sign + "】" + fmt.Sprintf(c.template, code))
+	otpText := code
+	if c.template != "" {
+		otpText = fmt.Sprintf(c.template, code)
+	}
+
+	smsContent := url.QueryEscape("【" + c.sign + "】" + otpText)
 	for _, mobile := range targetPhoneNumber {
 		if strings.HasPrefix(mobile, "+86") {
 			mobile = mobile[3:]

--- a/twilio.go
+++ b/twilio.go
@@ -47,8 +47,10 @@ func (c *TwilioClient) SendMessage(param map[string]string, targetPhoneNumber ..
 		return fmt.Errorf("missing parameter: code")
 	}
 
-	bodyContent := code 
-    if c.template != "" { bodyContent = fmt.Sprintf(c.template, code) }
+	bodyContent := code
+	if c.template != "" {
+		bodyContent = fmt.Sprintf(c.template, code)
+	}
 
 	if len(targetPhoneNumber) < 2 {
 		return fmt.Errorf("bad parameter: targetPhoneNumber")

--- a/twilio.go
+++ b/twilio.go
@@ -47,7 +47,8 @@ func (c *TwilioClient) SendMessage(param map[string]string, targetPhoneNumber ..
 		return fmt.Errorf("missing parameter: code")
 	}
 
-	bodyContent := fmt.Sprintf(c.template, code)
+	bodyContent := code 
+    if c.template != "" { bodyContent = fmt.Sprintf(c.template, code) }
 
 	if len(targetPhoneNumber) < 2 {
 		return fmt.Errorf("bad parameter: targetPhoneNumber")


### PR DESCRIPTION
When there's no **template code** is selected in the SMS provider editor page, the formatted SMS body ended up with unnecessary characters.

![image](https://github.com/user-attachments/assets/5f91252e-58b9-4b8c-be9c-9deb1733b69b)

This fix checks if the template code exists before formatting the code. 

Note: Updated all places but only tested with Twillio as I only got Twillio account